### PR TITLE
Fix/hero add logo top

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import Button from '../Button';
 import '../../styles/HeroSection.css';
+import elmentorLogo from '../../../assets/elmentor-logo-BmwUH4zI.png';
 
 export default function HeroSection() {
   const heroRef = useRef<HTMLElement>(null);
@@ -13,6 +14,14 @@ export default function HeroSection() {
       {/* Background pattern overlay is handled by CSS */}
       <div className="elmentor-hero-overlay"></div>
         <div className="elmentor-hero-content">
+          
+          <img 
+            src={elmentorLogo} 
+            alt="Elmentor Program Logo" 
+            className="elmentor-logo-top"
+            style={{ width: '200px', height: 'auto' }}
+          />
+
         <h1 className="elmentor-hero-title">
           Join Elmentor Program: A Private Community for Continuous Learning and Professional Growth.<br />
           <span className="elmentor-hero-slogan">Empower through mentorship.</span>

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -20,7 +20,7 @@ export default function HeroSection() {
             alt="Elmentor Program Logo" 
             className="elmentor-logo-top"
             style={{ width: '200px', height: 'auto' }}
-          />
+           />
 
         <h1 className="elmentor-hero-title">
           Join Elmentor Program: A Private Community for Continuous Learning and Professional Growth.<br />

--- a/src/styles/HeroSection.css
+++ b/src/styles/HeroSection.css
@@ -3,7 +3,7 @@
 
 .elmentor-hero {
   width: 100%;
-  min-height: 85vh;
+  min-height: 90vh;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses part of Issue #2 **"Rebuild Elmentor Program Website Using Clean Version With Key Enhancements"**.  
Specifically, it adds the **Elmentor Program logo** to the top of the first (hero) section, matching the placeholder position noted in the review.

## Changes Made
- Added `elmentor-logo.png` asset under `/public/assets/`.
- Updated `HeroSection.tsx` to render the logo above the main heading.
- Verified visual spacing between the logo and the main title.

## Why These Changes Are Needed
- Adding the Elmentor Program logo improves brand recognition and aligns with the reviewed mockups.

## Testing Performed
- Verified correct logo positioning in Google Chrome.

## Screenshots

**Before:**  
<img width="996" height="643" alt="Screenshot 2025-10-08 at 9 41 05 PM" src="https://github.com/user-attachments/assets/ee6b7a81-b650-4b42-b3bd-9906fbc3aa08" />

**After:**  
<img width="1023" height="665" alt="Screenshot 2025-10-08 at 7 56 30 PM" src="https://github.com/user-attachments/assets/e7baddf3-8153-410b-bba0-0b0d2ff30985" />

