### PR TITLE
Fix/intro section elmentor branding

### DIFF
--- a/src/components/sections/IntroductoryVideoSection.tsx
+++ b/src/components/sections/IntroductoryVideoSection.tsx
@@ -22,8 +22,8 @@ const IntroductoryVideoSection: React.FC = () => {
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
             loading="lazy"
-            aria-describedby="video-description"
-          ></iframe>
+            aria-describedby="video-description">
+            </iframe>
         </div>
         <p id="video-description" className="video-description">
           This introductory video provides an overview of the Elmentor Program, explaining how our mentorship 

--- a/src/components/sections/IntroductoryVideoSection.tsx
+++ b/src/components/sections/IntroductoryVideoSection.tsx
@@ -10,9 +10,9 @@ const IntroductoryVideoSection: React.FC = () => {
   return (
     <section id="intro-video" className="intro-video-section" aria-labelledby="video-title">
       <div className="intro-video-container">
-        <h2 id="video-title" className="intro-video-title">Discover DevOps Visions: Watch Our Introduction</h2>
+        <h2 id="video-title" className="intro-video-title">Discover Elmentor Program: Watch Our Introduction</h2>
         <p className="intro-video-subtitle">
-          Get a quick overview of the DevOps Visions Program and learn how it can help you achieve your career goals.
+          Get a quick overview of the Elmentor Program and learn how it can help you achieve your career goals.
         </p>
         <div className="video-responsive-wrapper">
           <iframe
@@ -26,7 +26,7 @@ const IntroductoryVideoSection: React.FC = () => {
           ></iframe>
         </div>
         <p id="video-description" className="video-description">
-          This introductory video provides an overview of the DevOps Visions Program, explaining how our mentorship 
+          This introductory video provides an overview of the Elmentor Program, explaining how our mentorship 
           approach can accelerate your professional development in the tech industry.
         </p>
 


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses part of Issue #2 **"Rebuild Elmentor Program Website Using Clean Version With Key Enhancements"**.  
Specifically, it updates the **Introductory Video Section** by replacing all instances of “Discover DevOps Division” with **“Discover Elmentor Program”**, aligning with the new program identity and consistent branding tone.

## Changes Made
- Updated main heading to: `Discover Elmentor Program: Watch Our Introduction`.
- Adjusted subtitle to reflect the Elmentor Program messaging.
- Updated all accessibility attributes (`alt`, `title`, `aria-label`) to remove references to “DevOps Division”.

## Why These Changes Are Needed
- To unify the website’s language and ensure full alignment with the new **Elmentor Program brand**.
- The previous “DevOps Division” wording was outdated.

## Testing Performed
- Verified text changes appear correctly.
- Confirmed video loads and plays normally after changes.

## Screenshots

**Before:**  
<img width="1003" height="774" alt="464673081-9d63ee80-a74c-4e5a-b0d0-b6b6ea068025" src="https://github.com/user-attachments/assets/f0e7a4ad-49c7-45f4-b88d-f7150ddae143" />


**After:**  
<img width="1033" height="796" alt="Screenshot 2025-10-08 at 7 56 15 PM" src="https://github.com/user-attachments/assets/cc95bd7e-074d-4e0c-9219-684b0b382954" />


## Additional Notes
- Text updates are consistent with the **About** section of the DevOps Visions blog.  
- This is one of several incremental PRs for Issue #2 to modernize and align branding across the site.
