### PR TITLE
fix: resolve TypeScript build errors in CommunityPresenceSection

### DIFF
--- a/src/components/sections/CommunityPresenceSection.tsx
+++ b/src/components/sections/CommunityPresenceSection.tsx
@@ -34,21 +34,18 @@ const ECOSYSTEM_LINKS = [  {
     url: 'https://github.com/ElmentorProgram',
     icon: <FaGithub />,
     category: 'Broader DevOps Visions Ecosystem',
-    logo: undefined,
   },
     {
     name: 'DevOps Visions GitHub',
     url: 'https://github.com/DevOpsVisions',
     icon: <FaGithub />,
     category: 'Broader DevOps Visions Ecosystem',
-    logo: undefined,
   },
   {
     name: 'DevOps Visions Public Community',
     url: 'https://devopsvisions.github.io/',
     icon: <FaGithub />, // ✅ you can swap this with FaBlog if you prefer
     category: 'Broader DevOps Visions Ecosystem',
-    logo: undefined,
   },
 ];
 

--- a/src/components/sections/CommunityPresenceSection.tsx
+++ b/src/components/sections/CommunityPresenceSection.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Button from '../Button';
 import '../../styles/CommunityPresenceSection.css';
 import { FaGithub, FaYoutube, FaFacebook, FaBlog } from 'react-icons/fa';
-import logoImage from '../../assets/images/elmentor-logo.svg';
 
 const COMMUNITY_LINKS = [
   {
@@ -35,18 +34,21 @@ const ECOSYSTEM_LINKS = [  {
     url: 'https://github.com/ElmentorProgram',
     icon: <FaGithub />,
     category: 'Broader DevOps Visions Ecosystem',
+    logo: undefined,
   },
     {
     name: 'DevOps Visions GitHub',
     url: 'https://github.com/DevOpsVisions',
     icon: <FaGithub />,
     category: 'Broader DevOps Visions Ecosystem',
+    logo: undefined,
   },
   {
     name: 'DevOps Visions Public Community',
     url: 'https://devopsvisions.github.io/',
     icon: <FaGithub />, // ✅ you can swap this with FaBlog if you prefer
     category: 'Broader DevOps Visions Ecosystem',
+    logo: undefined,
   },
 ];
 


### PR DESCRIPTION
- Remove unused 'logoImage' import
- Add missing 'logo' property to ECOSYSTEM_LINKS objects

This fixes the deployment CI failure caused by strict TypeScript settings flagging:
- Unused variables (TS6133)
- Missing object properties (TS2339)

# Pull Request

## Description
[Provide a brief description of the changes made in this PR]

## Changes Made
- [List the major changes made]
- 
- 

## Why These Changes Are Needed
[Explain why these changes are necessary]

## Testing Performed
- [Describe the testing performed to verify the changes]
- 

## Screenshots
[If applicable]

## Additional Notes
[Any additional information that might be helpful for reviewers]
