### PR TITLE
Feat/community gathering images

### DIFF
--- a/src/components/sections/CommunityGatheringSection.tsx
+++ b/src/components/sections/CommunityGatheringSection.tsx
@@ -29,7 +29,7 @@ const COMMUNITY_GATHERINGS = [  {    id: 'japan2022',
     title: 'KSA/Riyadh March 2024',
     location: 'Riyadh, KSA',
     date: 'March 2024',
-    image: 'https://raw.githubusercontent.com/MohamedRadwan-DevOps/devops-step-by-step/main/source/images/mics/egy-aug-24.jpg'
+    image: 'https://raw.githubusercontent.com/MohamedRadwan-DevOps/devops-step-by-step/main/source/images/mics/ksa-mar-24.jpg'
   },
   {
     id: 'egypt2024',

--- a/src/components/sections/CommunityGatheringSection.tsx
+++ b/src/components/sections/CommunityGatheringSection.tsx
@@ -23,6 +23,21 @@ const COMMUNITY_GATHERINGS = [  {    id: 'japan2022',
     date: 'April 2023',
     image: 'https://raw.githubusercontent.com/MohamedRadwan-DevOps/devops-step-by-step/main/source/images/mics/usa-apr-23.jpg'
   }
+  ,
+  {
+    id: 'ksa2024',
+    title: 'KSA/Riyadh March 2024',
+    location: 'Riyadh, KSA',
+    date: 'March 2024',
+    image: 'https://raw.githubusercontent.com/MohamedRadwan-DevOps/devops-step-by-step/main/source/images/mics/egy-aug-24.jpg'
+  },
+  {
+    id: 'egypt2024',
+    title: 'Egypt/Cairo August 2024',
+    location: 'Cairo, Egypt',
+    date: 'August 2024',
+    image: 'https://raw.githubusercontent.com/MohamedRadwan-DevOps/devops-step-by-step/main/source/images/mics/egy-aug-24.jpg'
+  }
 ];
 
 const CommunityGatheringSection: React.FC = () => {


### PR DESCRIPTION
## Description
This PR fixes an incorrect image used for the KSA community gathering in the Community Gathering section.

The previous implementation mistakenly displayed an Egypt gathering image for the KSA (Riyadh – March 2024) card.

---

## Changes Made
- Replaced the incorrect EGY gathering image with the correct Riyadh March 2024 image.
- No layout or styling changes were introduced.

---

## Why These Changes Are Needed
Using accurate images for each community gathering is important to properly represent real events and maintain trust and clarity in the Elmentor community timeline.

This fix ensures the KSA gathering is displayed with its correct visual content.

---

## Testing Performed
- Verified the Community Gathering section renders correctly.
- Confirmed the KSA card now displays the correct image.
- Ensured no other gathering images were affected.

---

## Context
- Follow-up fix for PR #9  
- Requested by @MohamedRadwan-DevOps

---

## Screenshots

**Before:**  
*(KSA card showing Egypt August 2024 image)*  
<img width="998" height="766" alt="Screenshot 2025-12-22 at 8 45 53 PM" src="https://github.com/user-attachments/assets/96882631-1c7d-4fbf-ac67-caa0a56ce450" />


**After:**  
*(KSA card showing correct Riyadh March 2024 image)*  
<img width="998" height="766" alt="Screenshot 2025-12-22 at 9 29 30 PM" src="https://github.com/user-attachments/assets/d8783fec-4e73-48a7-b3fe-b0781069fe12" />